### PR TITLE
[Fix] Release workflow configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ jobs:
         id: package_version
         run: echo "::set-output name=version::$(grep '\"version\"' package.json | cut -d '\"' -f 4)"
 
+      - name: Push Git Tag
+        run: |
+          TAG="v${{ steps.package_version.outputs.version }}"
+          git tag $TAG
+          git push origin $TAG
+
       - name: Get Changelog Entry
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
@@ -29,8 +35,8 @@ jobs:
       - name: Create/update release
         uses: ncipollo/release-action@v1
         with:
-          tag: v${{ steps.changelog_reader.outputs.version }}
-          name: v${{ steps.changelog_reader.outputs.version }}
+          tag: v${{ steps.package_version.outputs.version }}
+          name: v${{ steps.package_version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }}
           allowUpdates: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from package.json
-        id: package_version
-        run: echo "::set-output name=version::$(grep '\"version\"' package.json | cut -d '\"' -f 4)"
+      - name: Check for version update in package.json
+        id: check_version
+        uses: EndBug/version-check@v2
 
       - name: Push Git Tag
         run: |
-          TAG="v${{ steps.package_version.outputs.version }}"
+          TAG="v${{ steps.check_version.outputs.version }}"
           git tag $TAG
           git push origin $TAG
 
@@ -29,14 +29,14 @@ jobs:
         uses: mindsers/changelog-reader-action@v2
         with:
           validation_level: warn
-          version: ${{ steps.package_version.outputs.version }}
+          version: ${{ steps.check_version.outputs.version }}
           path: ./CHANGELOG.md
 
       - name: Create/update release
         uses: ncipollo/release-action@v1
         with:
-          tag: v${{ steps.package_version.outputs.version }}
-          name: v${{ steps.package_version.outputs.version }}
+          tag: v${{ steps.check_version.outputs.version }}
+          name: v${{ steps.check_version.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }}
           allowUpdates: true
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Release Workflow on PR Merge
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
 
 jobs:
   create-release:
@@ -20,18 +18,19 @@ jobs:
         id: package_version
         run: echo "::set-output name=version::$(grep '\"version\"' package.json | cut -d '\"' -f 4)"
 
-      - name: Extract Changelog for Current Version
-        id: changelog
-        run: |
-          VERSION=${{ steps.package_version.outputs.version }}
-          CHANGELOG_CONTENT=$(awk -v ver="$VERSION" 'BEGIN {p=0; first=1} $0 ~ "## \\[" ver "\\]" {p=1; next} /^## \[/ {if(p) exit} p{if (first && /^$/) {first=0; next} print}' CHANGELOG.md)
-          echo "::set-output name=content::${CHANGELOG_CONTENT}"
-
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get Changelog Entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v2
         with:
-          tag_name: v${{ steps.package_version.outputs.version }}
-          release_name: Release v${{ steps.package_version.outputs.version }}
-          body: ${{ steps.changelog.outputs.content }}
+          validation_level: warn
+          version: ${{ steps.package_version.outputs.version }}
+          path: ./CHANGELOG.md
+
+      - name: Create/update release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ steps.changelog_reader.outputs.version }}
+          name: v${{ steps.changelog_reader.outputs.version }}
+          body: ${{ steps.changelog_reader.outputs.changes }}
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Check for version update in package.json
         id: check_version
         uses: EndBug/version-check@v2
@@ -30,7 +35,6 @@ jobs:
         with:
           validation_level: warn
           version: ${{ steps.check_version.outputs.version }}
-          path: ./CHANGELOG.md
 
       - name: Create/update release
         uses: ncipollo/release-action@v1

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,4 @@
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
   "typescript.tsc.autoDetect": "off",
   "YOCO.includeFilePath": true,
-  "githubPullRequests.ignoredPullRequestBranches": [
-    "dev"
-  ]
 }


### PR DESCRIPTION
Closes #54

## Description

- As-is
  - Manually extract the version from package.json to create and push a git tag
- To-be
  - Utilize well-structured workflows from the GitHub Action Marketplace:
    - EndBug/version-check@v2: Extract the version from package.json
    - mindsers/changelog-reader-action@v2: Applicable only if the changelog is written according to the [Keep a Changelog](http://keepachangelog.com/) format.
    - ncipollo/release-action@v1: Updates the release notes.

## ETC

- 지난 배포 때 의도치 않게 포함된 .vscode/settings.json 파일 변경사항 복구
- 개인 테스트 레포지토리 생성해서 테스트한 결과입니다! Changelog 내용도 한 줄일 때와 여러 줄일 때 테스트 모두 통과했습니다.
<img width="1333" alt="스크린샷 2024-05-14 오전 12 14 25" src="https://github.com/YOCOING/YOCO/assets/63575891/cafa434c-8666-4e55-8981-bc0384ebe0df">
<img width="1190" alt="스크린샷 2024-05-14 오전 12 01 57" src="https://github.com/YOCOING/YOCO/assets/63575891/e2958a38-9844-46a0-bd20-d7ec1402b710">
<img width="554" alt="스크린샷 2024-05-14 오전 12 09 58" src="https://github.com/YOCOING/YOCO/assets/63575891/414540bf-98a1-4300-93af-96cea3bb1de7">

## Checklist (Merge should only be performed once all of the following conditions are checked.)

- [x] I have completed the necessary tests and verified that the functionality works as intended.
- [x] I have written the code according to the code style guide.
- [x] I have confirmed that only the intended files and changes have been committed.
- [x] I have discussed these changes with my team members in advance, and all team members are aware of this PR.
