### PR TITLE
[feat] set default backticks option to false

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         },
         "YOCO.useBacktick": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Wrap codeblock with backticks"
         }
       }


### PR DESCRIPTION
Closes #61

## Description

- `YOCO.useBacktick` wrapping code blocks with backticks was set as `true` by default. It's not intended initially so that convert it to `false` to be default. 

## ETC

-
-

## Checklist (Merge should only be performed once all of the following conditions are checked.)

- [x] I have completed the necessary tests and verified that the functionality works as intended.
- [x] I have written the code according to the code style guide.
- [x] I have confirmed that only the intended files and changes have been committed.
- [x] I have discussed these changes with my team members in advance, and all team members are aware of this PR.
